### PR TITLE
Add previous button

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Standup order in JIRA",
   "description": "Randomise a list of attendees and show on a JIRA scrum board to determine standup order.",
-  "version": "1.8",
+  "version": "1.9",
   "manifest_version": 3,
   "icons": {
     "16": "images/icon@16px.png",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -158,8 +158,8 @@ function isCurrent(person) {
 
   {#if !isEditing}
     {#if state.shuffled.length > 0}
-      <button class="aui-button" on:click={onNextClick}><NextIcon /></button>
       <button class="aui-button" on:click={onPreviousClick}><PreviousIcon /></button>
+      <button class="aui-button" on:click={onNextClick}><NextIcon /></button>
       <button class="aui-button" on:click={shuffleAttendees}><ShuffleIcon /></button>
     {/if}
     <button class="aui-button" on:click={onAddClick}><PlusIcon /></button>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -9,6 +9,7 @@
   import CheckIcon from "./icons/CheckIcon.svelte";
   import CancelIcon from "./icons/CancelIcon.svelte";
   import NextIcon from "./icons/NextIcon.svelte";
+  import PreviousIcon from "./icons/PreviousIcon.svelte";
 
   let state = getState();
   $: setState(state);
@@ -74,6 +75,24 @@
     }
   }
 
+  function onPreviousClick() {
+    const unSkippedAttendees = state.shuffled.filter(s => !state.skipped.some(h => h === s));
+
+    if (state.currentAttendee === null) {
+      state.currentAttendee = unSkippedAttendees[unSkippedAttendees.length - 1];
+      return;
+    }
+
+    const currentIndex = unSkippedAttendees.indexOf(state.currentAttendee);
+    const previousIndex = currentIndex - 1;
+
+    if (previousIndex >= 0) {
+      state.currentAttendee = unSkippedAttendees[previousIndex];
+    } else {
+      state.currentAttendee = null;
+    }
+  }
+
   /**
    * @param {string} person
    */
@@ -129,6 +148,7 @@ function isCurrent(person) {
   {#if !isEditing}
     {#if state.shuffled.length > 0}
       <button class="aui-button" on:click={onNextClick}><NextIcon /></button>
+      <button class="aui-button" on:click={onPreviousClick}><PreviousIcon /></button>
       <button class="aui-button" on:click={shuffleAttendees}><ShuffleIcon /></button>
     {/if}
     <button class="aui-button" on:click={onAddClick}><PlusIcon /></button>

--- a/src/icons/PreviousIcon.svelte
+++ b/src/icons/PreviousIcon.svelte
@@ -1,0 +1,3 @@
+<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg">
+    <path d="m19 12-7-5v10zM5 7v10l7-5z"></path>
+</svg>


### PR DESCRIPTION
Adds a previous button in case you accidentally move past a person who hasn't had their turn.

![Screen Recording 2023-05-12 at 10 44 22 AM](https://github.com/Cryptacular/jira-standup-order/assets/105895919/29546c15-778e-482b-8449-e5e5cee472c9)

(The Next and Previous buttons have been swapped around since this demo was recorded.)
