### PR TITLE
Automatically shift people up/down the list when skipping/unskipping them

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Standup order in JIRA",
   "description": "Randomise a list of attendees and show on a JIRA scrum board to determine standup order.",
-  "version": "2.6",
+  "version": "2.7",
   "manifest_version": 3,
   "icons": {
     "16": "images/icon@16px.png",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -193,6 +193,7 @@
    */
   function handleSkip(userId) {
     state = {...state, attendees: state.attendees.map(a => a.id === userId ? {...a, isSkipped: true} : a) };
+    state.shuffled.push(state.shuffled.splice(state.shuffled.indexOf(userId), 1)[0]);
     trackStateChanged(projectId);
   }
 
@@ -201,6 +202,14 @@
    */
   function handleUnskip(userId) {
     state = {...state, attendees: state.attendees.map(a => a.id === userId ? {...a, isSkipped: false} : a) };
+    
+    const currIndex = state.shuffled.indexOf(userId);
+    const newIndex = state.shuffled.findIndex((sid) => { return state.attendees.find(a => a.id === sid && a.isSkipped) !== undefined });
+
+    if (newIndex !== currIndex + 1) {
+      state.shuffled.splice(newIndex < 0 ? state.shuffled.length - 1 : newIndex, 0, state.shuffled.splice(currIndex, 1)[0]);
+    }
+
     trackStateChanged(projectId);
   }
 


### PR DESCRIPTION
Automatically shift a person being skipped to the end of the order and shift a person being unskipped to the end of the unskipped list.

This makes for a nicer experience when people drop in/out of stand-up part way through.

![ScreenRecording2024-01-26at2 34 38PM-ezgif com-video-to-gif-converter](https://github.com/Cryptacular/jira-standup-order/assets/105895919/0830de62-2cad-4a47-97a4-ac59a5f5b40b)
